### PR TITLE
2 small changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   },
   "homepage": "https://github.com/joehand/url-dat#readme",
   "devDependencies": {
+    "hyperdrive": "^7.12.2",
     "memdb": "^1.3.1",
-    "tap-spec": "^4.1.1"
+    "tap-spec": "^4.1.1",
+    "tape": "^4.6.3"
   },
   "dependencies": {
     "pump": "^1.0.1",

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ var urlDat = require('.')
 test('puts urls into archive', function (t) {
   var drive = hyperdrive(memdb())
   var archive = drive.createArchive()
-  var urls = ['http://dat-data.com']
+  var urls = ['https://datproject.org']
 
   urlDat(urls, archive, function (err) {
     t.error(err)
@@ -16,7 +16,7 @@ test('puts urls into archive', function (t) {
       t.ok(archive.key.toString('hex'), 'has key')
       archive.get(0, function (err, entry) {
         if (err) throw err
-        t.ok(entry.name.indexOf('dat-data') > -1, 'gets entry')
+        t.ok(entry.name.indexOf('datproject') > -1, 'gets entry')
         t.end()
       })
     })


### PR DESCRIPTION
1) there were two missing dev deps for test to run, so added
2) dat-data.com apparently has been migrated to datproject.org, so that's been updated in test.js